### PR TITLE
build: bump Apache parent POM from 25 to 37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>25</version>
+        <version>37</version>
     </parent>
 
     <groupId>org.apache.druid</groupId>


### PR DESCRIPTION
Bumps the Apache parent POM version from 25 to 37.